### PR TITLE
Add/vpc peering connection id optional variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,9 +11,10 @@ locals {
 }
 
 resource "aws_route" "to_tgw" {
-  for_each                   = local.merged_routes
-  route_table_id             = lookup(each.value, "rtb_id")
-  transit_gateway_id         = var.transit_gateway_id != "" ? var.transit_gateway_id : null
+  for_each       = local.merged_routes
+  route_table_id = lookup(each.value, "rtb_id")
+  # only one of transit_gateway_id or vpc_peering_connection_id may be set. So if the vpc_peer_conn_id is set this will be null.
+  transit_gateway_id         = var.vpc_peering_connection_id != "" ? null : var.transit_gateway_id
   destination_cidr_block     = lookup(each.value, "route", null)
   destination_prefix_list_id = lookup(each.value, "prefix_list_id", null)
   vpc_peering_connection_id  = var.vpc_peering_connection_id != "" ? var.vpc_peering_connection_id : null

--- a/main.tf
+++ b/main.tf
@@ -16,4 +16,5 @@ resource "aws_route" "to_tgw" {
   transit_gateway_id         = var.transit_gateway_id
   destination_cidr_block     = lookup(each.value, "route", null)
   destination_prefix_list_id = lookup(each.value, "prefix_list_id", null)
+  vpc_peering_connection_id  = var.vpc_peering_connection_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -26,3 +26,9 @@ variable "prefix_list_ids" {
   default     = []
   type        = list(string)
 }
+
+variable "vpc_peering_connection_id" {
+  description = "Optional ID of VPC peering connection - useful if you're creating routes for a peered VPC"
+  default     = ""
+  type        = string
+}


### PR DESCRIPTION
Added ability to pass the "vpc_peering_connection_id" variable into the route creation.
This argument is useful when creating routes to subnets that are on a peered remote VPC.

This argument is exclusive with the "transit gateway id" argument in the aws_route resource, so I added logic to evaluate the existance of the peering connection ID variable, and make the transit gateway "null" only when this argument is passed.